### PR TITLE
Fix dangling input port (i_set_d) warning in acredit_src

### DIFF
--- a/base_acredit_src.sv
+++ b/base_acredit_src.sv
@@ -18,43 +18,38 @@
  *
  * Author: Andrew K Martin akmartin@us.ibm.com
  */
- 
+
 module base_acredit_src#
-  (
-   parameter credits = 0,
-   parameter log_credits = $clog2(credits+1)
-   )
-   (
-    input  clk,
-    input  reset,
-    
-    output i_r,
-    input  i_v,
+(
+  parameter credits = 0,
+  parameter log_credits = $clog2(credits+1)
+)
+(
+  input  clk,
+  input  reset,
 
-    input  o_c,
-    input  o_r,
-    output o_v
-    );
+  output i_r,
+  input  i_v,
 
-   wire    credit_z;
-   
-   wire    s1_c;
-   base_vlat#(.width(1)) iclat (.clk(clk),.reset(reset),.din(o_c),.q(s1_c));
-   base_incdec#(.width(log_credits),.rstv(credits)) iincdec(.clk(clk),.reset(reset),.i_set_v(1'b0),.i_set_d(),.i_inc(s1_c),.i_dec(i_r & i_v),.o_zero(credit_z),.o_cnt());
+  input  o_c,
+  input  o_r,
+  output o_v
+);
 
-   wire    credit_r = ~credit_z;
-   assign i_r = o_r & credit_r;
-   assign o_v = i_v & credit_r;
-   
+  wire credit_z;
+  wire s1_c;
+
+  base_vlat#(.width(1)) iclat (.clk(clk),.reset(reset),.din(o_c),.q(s1_c));
+
+  wire [log_credits-1:0] i_set_d = 0;
+  base_incdec#(.width(log_credits),.rstv(credits)) iincdec (
+    .clk(clk),.reset(reset),
+    .i_set_v(1'b0),.i_set_d(i_set_d),.i_inc(s1_c),.i_dec(i_r & i_v),
+    .o_zero(credit_z),.o_cnt()
+  );
+
+  wire   credit_r = ~credit_z;
+  assign i_r = o_r & credit_r;
+  assign o_v = i_v & credit_r;
+
 endmodule // base_acredit_src
-
-
-
-    
-   
-					
-   
-
-
-   
-  


### PR DESCRIPTION
The Icarus Verilog compiler gave a dangling input port warning for input port 4 (`i_set_d`) of the `incdec` module within the `acredit_src` module. This is fixed by declaring a wire equal to zero of `log_credits` width.