### PR TITLE
Fix base_acredit_snk and base_initsm and update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,10 @@
 # dicells
 Cell Library for Delay Insensitive Synchronous Hardware
 
-This library has been in use for several years, and has evolved over that time.  It's definitely time for an overhaul, with better naming, documentation etc.   I'll work on this as I can in the next few months.
+This library has been in use for several years, and has evolved over that time. It's definitely time for an overhaul, with better naming, documentation etc. I'll work on this as I can in the next few months.
 
-Also, it needs a verification infrastructure so that changes can be made easily with confidence that nothing was broken.  Ideally, I'd like to see an automated FV process.  I'm open to suggestions, but I'm thinking hard about
-using ACL2, mostly because I think, with work, it could handle the verilog prameterization in a nice way.
+Also, it needs a verification infrastructure so that changes can be made easily with confidence that nothing was broken. Ideally, I'd like to see an automated FV process. I'm open to suggestions, but I'm thinking hard about using ACL2, mostly because I think, with work, it could handle the Verilog parameterization in a nice way.
 
+## Examples
+The following repository contains a design using the cell library:
+- [multi-stream-buffer](https://github.com/ytbmulder/multi-stream-buffer)

--- a/base_acredit_snk.sv
+++ b/base_acredit_snk.sv
@@ -18,36 +18,42 @@
  *
  * Author: Andrew K Martin akmartin@us.ibm.com
  */
-
+ 
 module base_acredit_snk#
-(
-  parameter credits     = 0,
-  parameter log_credits = $clog2(credits),
-  parameter width       = 0,
-  parameter dist_ram    = 0,
-  parameter block_ram   = 0,
-  parameter output_reg  = 1
-)
-(
-  input                 clk,
-  input                 reset,
-
-  input                 i_v,
-  input  [0:width-1]    i_d,
-  output                i_c,
-
-  input                 o_r,
-  output                o_v,
-  output [0:width-1]    o_d
-);
-
-  base_fifo#(.width(width),.LOG_DEPTH(log_credits),.DEPTH(credits),.output_reg(output_reg)) i_fifo
   (
-  .clk(clk),.reset(reset),
-  .i_r(),.i_v(i_v),.i_d(i_d),
-  .o_v(o_v),.o_r(o_r),.o_d(o_d)
-  );
+   parameter credits =  0,
+   parameter log_credits = $clog2(credits),
+   parameter width = 0,
+   parameter dist_ram=0,
+   parameter block_ram=0
+   )
+   (
+    input 	       clk,
+    input 	       reset,
+    output 	       i_c,
+    input 	       i_v,
+    input [0:width-1]  i_d,
+    
+    input 	       o_r,
+    output 	       o_v,
+    output [0:width-1] o_d
+    );
 
-  base_vlat#(.width(1)) il1(.clk(clk),.reset(reset),.din(o_v&o_r),.q(i_c));
-
+   base_fifo#(.width(width),.LOG_DEPTH(log_credits),.DEPTH(credits),.output_reg(1)) i_fifo
+     (
+      .clk(clk),.reset(reset),
+      .i_r(),.i_v(i_v),.i_d(i_d),
+      .o_v(o_v),.o_r(o_r),.o_d(o_d)
+      );
+   base_vlat#(.width(1)) il1(.clk(clk),.reset(reset),.din(o_v&o_r),.q(i_c));
 endmodule // base_acredit_snk
+
+
+    
+   
+					
+   
+
+
+   
+  

--- a/base_acredit_snk.sv
+++ b/base_acredit_snk.sv
@@ -18,42 +18,36 @@
  *
  * Author: Andrew K Martin akmartin@us.ibm.com
  */
- 
+
 module base_acredit_snk#
+(
+  parameter credits     = 0,
+  parameter log_credits = $clog2(credits),
+  parameter width       = 0,
+  parameter dist_ram    = 0,
+  parameter block_ram   = 0,
+  parameter output_reg  = 1
+)
+(
+  input                 clk,
+  input                 reset,
+
+  input                 i_v,
+  input  [0:width-1]    i_d,
+  output                i_c,
+
+  input                 o_r,
+  output                o_v,
+  output [0:width-1]    o_d
+);
+
+  base_fifo#(.width(width),.LOG_DEPTH(log_credits),.DEPTH(credits),.output_reg(output_reg)) i_fifo
   (
-   parameter credits =  0,
-   parameter log_credits = $clog2(credits),
-   parameter width = 0,
-   parameter dist_ram=0,
-   parameter block_ram=0
-   )
-   (
-    input 	       clk,
-    input 	       reset,
-    output 	       i_c,
-    input 	       i_v,
-    input [0:width-1]  i_d,
-    
-    input 	       o_r,
-    output 	       o_v,
-    output [0:width-1] o_d
-    );
+  .clk(clk),.reset(reset),
+  .i_r(),.i_v(i_v),.i_d(i_d),
+  .o_v(o_v),.o_r(o_r),.o_d(o_d)
+  );
 
-   base_fifo#(.width(width),.LOG_DEPTH(log_credits),.DEPTH(credits),.output_reg(1)) i_fifo
-     (
-      .clk(clk),.reset(reset),
-      .i_r(),.i_v(i_v),.i_d(i_d),
-      .o_v(o_v),.o_r(o_r),.o_d(o_d)
-      );
-   base_vlat#(.width(1)) il1(.clk(clk),.reset(reset),.din(o_v&o_r),.q(i_c));
+  base_vlat#(.width(1)) il1(.clk(clk),.reset(reset),.din(o_v&o_r),.q(i_c));
+
 endmodule // base_acredit_snk
-
-
-    
-   
-					
-   
-
-
-   
-  


### PR DESCRIPTION
This PR contains fixes for the following cells:
- `base_acredit_snk`: Fix dangling input port (i_set_d) warning in base_acredit_src
- `base_initsm`: Add zero output to base_initsm